### PR TITLE
Error: The target “BlackJack2” contains source code developed with Swift 2.x…

### DIFF
--- a/BlackJack2/Card.swift
+++ b/BlackJack2/Card.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-
+ 
 class Card {
     let suit: String
     let rank: String


### PR DESCRIPTION
…. Xcode 9 does not support building or migrating Swift 2.x targets.

Use Xcode 8.x to migrate the code to Swift 3.